### PR TITLE
Migrating for express 4.x

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var util = require('util');
 var datetime = require('datetime');
-var express = require('express');
+var morgan = require('morgan');
 var mkdirsSync = require('mkdir').mkdirsSync;
 
 // *************************************************************************************************
@@ -17,7 +17,7 @@ module.exports = function(options) {
     mkdirsSync(path.dirname(options.path));
 
     var logStream = fs.createWriteStream(options.path, {flags: 'a'});
-    var logger = express.logger({stream: logStream, format: options.format});
+    var logger = morgan({stream: logStream, format: options.format});
 
     // XXXjoe Need to expose a way to cancel this timer
     var archiveInterval = setInterval(function() {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "author": "Joe Hewitt <joe@joehewitt.com>",
   "dependencies": {
     "datetime": "",
-    "express": "2.5.9",
-    "mkdir": ""
+    "mkdir": "",
+    "morgan": "^1.8.2"
   },
   "engines": {
     "node": ">=0.4.0"


### PR DESCRIPTION
using morgan logger package instead of deprecated (and removed) express.logger